### PR TITLE
Fix CDATA end token in HTMLWriter

### DIFF
--- a/src/java/org/dom4j/io/HTMLWriter.java
+++ b/src/java/org/dom4j/io/HTMLWriter.java
@@ -262,7 +262,7 @@ public class HTMLWriter extends XMLWriter {
     }
 
     public void endCDATA() throws SAXException {
-        if (disabled) super.startCDATA();
+        if (disabled) super.endCDATA();
     }
 
     // Overloaded methods


### PR DESCRIPTION
endCDATA() method from HTMLWriter class calls super.startCDATA(). I think super.endCDATA() should be called instead.

Currently calling:
A.startCDATA();
A.endCDATA();
will produce:
<![CDATA[<![CDATA[
instead of desired:
<![CDATA[]]>

This pull request fixes the problem.
