### PR TITLE
org.dom4j.DocumentFactory.getInstance throws

### DIFF
--- a/src/java/org/dom4j/DocumentFactory.java
+++ b/src/java/org/dom4j/DocumentFactory.java
@@ -91,10 +91,18 @@ public class DocumentFactory implements Serializable {
      * @return the default singleon instance
      */
     public static synchronized DocumentFactory getInstance() {
-        if (singleton == null) {
-            singleton = createSingleton();
+        try
+        {
+            if (singleton == null) {
+                singleton = createSingleton();
+            }
+            return (DocumentFactory) singleton.instance();
         }
-        return (DocumentFactory) singleton.instance();
+        catch(ClassCastException ex)
+        {
+        	System.out.println("WARNING: Unable to cast to org.dom4j.DocumentFactory. Using default DocumentFactory.");
+        	return new DocumentFactory();
+        }
     }
 
     // Factory methods

--- a/src/java/org/dom4j/DocumentFactory.java
+++ b/src/java/org/dom4j/DocumentFactory.java
@@ -100,7 +100,7 @@ public class DocumentFactory implements Serializable {
         }
         catch(ClassCastException ex)
         {
-        	System.out.println("WARNING: Unable to cast to org.dom4j.DocumentFactory. Using default DocumentFactory.");
+        	System.out.println("[WARNING] Using default org.dom4j.DocumentFactory");
         	return new DocumentFactory();
         }
     }


### PR DESCRIPTION
Apparently a fix that is in the createSingleton(String name) class is not applied in createSingleton(). It causes the getInstance to throw "java.lang.ClassCastException: org.dom4j.DocumentFactory cannot be cast to org.dom4j.DocumentFactory" whenever there is class loader mismatch.

There is couple of bug reports filed that report similar behaviour I was experiencing:
JENKINS-15344
JENKINS-13709
JENKINS-7666
JENKINS-17488
